### PR TITLE
Remove G_DISABLE_CHECKS macro

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ cdata.set_quoted('GETTEXT_PACKAGE', json_gettext_domain)
 
 ndebug = get_option('b_ndebug')
 if ndebug == 'true' or (ndebug == 'if-release' and not get_option('debug'))
-  add_project_arguments(['-DG_DISABLE_CAST_CHECKS', '-DG_DISABLE_ASSERT', '-DG_DISABLE_CHECKS'],
+  add_project_arguments(['-DG_DISABLE_CAST_CHECKS', '-DG_DISABLE_ASSERT'],
                         language: 'c')
 endif
 


### PR DESCRIPTION
The following code will crash if json-glib is compiled with `-DG_DISABLE_CHECKS`:
```c
#include <json-glib/json-glib.h>
int main ()
{
  const char* raw_message = "{\"payload\":{}}";
  JsonNode *message = json_from_string (raw_message, NULL);
  JsonObject *root = json_node_get_object (message);
  JsonObject *payload = json_object_ref (json_object_get_object_member (root, "payload"));
  JsonObject *crash = json_object_get_object_member (payload, "crash");
  return 0;
}
```
Because json-glib use `g_return_val_if_fail` to do some checks and if `G_DISABLE_CHECKS` is defined then the check is not performed.
https://github.com/frida/json-glib/blob/1c5ad341f575a4a715a7461f2455a7ecf1a2db0e/json-glib/json-object.c#L894-L899